### PR TITLE
DOC: Fix sites' information

### DIFF
--- a/content/sites/ankara.md
+++ b/content/sites/ankara.md
@@ -1,5 +1,5 @@
 ---
-title: Brainhack Ankara, Turkey
+title: Brainhack Ankara
 organizers:
   - Meltem Atay
 contact: meltemiatay@gmail.com

--- a/content/sites/atlanta.md
+++ b/content/sites/atlanta.md
@@ -4,10 +4,10 @@ organizers:
   - Yasmine Bassil
 contact: yasminebassil@gatech.edu
 website:
-address: TReNDS center (the Center for Translational Research in Neuroimaging and Data Science) at Georgia State University
+address: TReNDS center (the Center for Translational Research in Neuroimaging and Data Science) at Georgia State University, Atlanta, GA, USA
 position:
-  lat: 33.7558332
-  lng: -84.3878563
+  lat: 33.7558754
+  lng: -84.3896796
 dates:
   - 2019-11-13
   - 2019-11-14

--- a/content/sites/austin.md
+++ b/content/sites/austin.md
@@ -5,10 +5,10 @@ organizers:
   - Daniel Margulies
 contact: cameron.craddock@austin.utexas.edu
 website: http://computational-neuroimaging-lab.org/
-address: 1601 Trinity St, Austin, TX 78701
+address: 1601 Trinity St, Austin, TX 78701, USA
 position:
-  lat: 30.2772353
-  lng: -97.7372389
+  lat: 30.277313
+  lng: -97.734812
 dates:
   - 2019-11-13
   - 2019-11-14

--- a/content/sites/eugene.md
+++ b/content/sites/eugene.md
@@ -1,13 +1,13 @@
 ---
-title: Brainhack Eugene, OR
+title: Brainhack Eugene 
 organizers: 
   - Kate Mills
 contact: klmills@uoregon.edu
 website: https://brainhack-eugene.github.io
-address: University of Oregon
+address: University of Oregon, Eugene, OR, USA
 position:
-  lat: 44.0448302
-  lng: -123.0726055
+  lat: 44.044834
+  lng: -123.0747995
 dates:
   - 2019-11-15
   - 2019-11-16

--- a/content/sites/london-ca.md
+++ b/content/sites/london-ca.md
@@ -1,5 +1,5 @@
 ---
-title: Brainhack London, Canada
+title: Brainhack London Canada
 organizers: 
   - Ali Khan
   - Marieke Mur
@@ -15,10 +15,10 @@ organizers:
   - Dimuthu Hemachandra
 contact: brainhack.western@gmail.com
 website: https://brainhackwestern.github.io/
-address: Western Science Centre, Laureen O. Paterson Building, Western University
+address: Western Science Centre, Laureen O. Paterson Building, Western University, London, ON, Canada
 position:
-  lat: 43.0099697
-  lng: -81.2714448
+  lat: 43.0099736
+  lng: -81.2736388
 dates:
   - 2019-11-13
   - 2019-11-14

--- a/content/sites/marburg.md
+++ b/content/sites/marburg.md
@@ -4,7 +4,7 @@ organizers:
   - Lydia Riedl
 contact: riedll@staff.uni-marburg.de
 website:
-address:
+address: Marburg, Hessen, Germany
 position:
   lat: 50.8066021
   lng: 8.7632194

--- a/content/sites/newjersey.md
+++ b/content/sites/newjersey.md
@@ -7,10 +7,10 @@ organizers:
   - Karina Tachihara
 contact: sam.nastase@gmail.com
 website:
-address: Princeton Neuroscience Institute and Peretsman Scully Hall, Princeton University, Princeton
+address: Princeton Neuroscience Institute and Peretsman Scully Hall, Princeton University, Princeton, NJ, USA
 position:
-  lat: 40.34307
-  lng: -74.6525721
+  lat: 40.3434412
+  lng: -74.6544729
 dates:
   - 2019-11-13
   - 2019-11-14

--- a/content/sites/rennes.md
+++ b/content/sites/rennes.md
@@ -4,10 +4,10 @@ organizers:
   - Julie Coloigner
 contact: julie.coloigner@irisa.fr
 website:
-address: Inria Research Centre, Domaine de Voluceau, 78150
+address: IRISA/Inria Rennes, Campus de Beaulieu 35000 Rennes, Bretagne, France
 position:
-  lat: 48.8378281
-  lng: 2.1030058
+  lat: 48.1151893
+  lng: -1.6431373
 dates:
   - 2019-11-14
   - 2019-11-15

--- a/content/sites/utrecht.md
+++ b/content/sites/utrecht.md
@@ -6,7 +6,7 @@ organizers:
   - Anastasia Osoianu
 contact: brainhacksynergy@gmail.com
 website: https://brainhacksynergy.github.io/
-address:
+address: Utrecht and The Hague, The Netherlands 
 position:
   lat: 52.0833341
   lng: 5.1454323

--- a/content/sites/zagreb.md
+++ b/content/sites/zagreb.md
@@ -3,11 +3,11 @@ title: Brainhack Zagreb, Croatia
 organizers:
   - Andrija Stajduhar
 contact: brainhacksynergy@gmail.com
-website: https://brainhacksynergy.github.io/
-address:
+website: https://brainhackzg.github.io/
+address: Five, Heinzelova ul. 33, Zagreb, Croatia
 position:
-  lat: 45.8381337
-  lng: 15.836036
+  lat: 45.810946
+  lng: 16.001664
 dates:
   - 2019-11-16
   - 2019-11-17


### PR DESCRIPTION
Fix sites' information:
- Fix the Brainhack Croatia website URL.
- Fix the address of some of the venues based on the local site web
  information.
- Make the coordinates match the venue/address.
- Increase consistency by adding the country in the sites' addresses.