### PR TITLE
DOC: Increase consistency in event names

### DIFF
--- a/content/sites/cambridge.md
+++ b/content/sites/cambridge.md
@@ -1,11 +1,11 @@
 ---
-title: Brainhack Cambridge, UK
+title: Brainhack Cambridge
 organizers: 
   - Lena Dorfschmidt
   - Jakub Vohryzek
 contact: oxbridgebrainhack@gmail.com
 website: 
-address: 
+address: Oxford-Cambridge, UK
 position:
   lat: 52.1732704
   lng: 0.139658

--- a/content/sites/zagreb.md
+++ b/content/sites/zagreb.md
@@ -1,5 +1,5 @@
 ---
-title: Brainhack Zagreb, Croatia
+title: Brainhack Zagreb
 organizers:
   - Andrija Stajduhar
 contact: brainhacksynergy@gmail.com


### PR DESCRIPTION
Increase consistency in event names: remove the country and keep it in
the venue.